### PR TITLE
Minor modification, in the tutorial on solvation of small molecules.

### DIFF
--- a/docs/Explicit-solvation.rst
+++ b/docs/Explicit-solvation.rst
@@ -39,7 +39,7 @@ Example 1. Solvation, MM minimization and classical MM dynamics for 100 ps.
         integrator='LangevinMiddleIntegrator', coupling_frequency=1, trajectory_file_option='DCD', enforcePeriodicBox=True)
 
     #MDAnalysis transforming of trajectory
-    lastframe_elems, lastframe_coords = MDAnalysis_transform("final_MDfrag_laststep.pdb","output_traj.dcd", solute_indices=soluteatoms, 
+    lastframe_elems, lastframe_coords = MDAnalysis_transform("final_MDfrag_laststep.pdb","trajectory.dcd", solute_indices=soluteatoms, 
         trajoutputformat='PDB')
 
     #new ASH fragment after the classical prep

--- a/docs/Explicit-solvation.rst
+++ b/docs/Explicit-solvation.rst
@@ -26,17 +26,17 @@ Example 1. Solvation, MM minimization and classical MM dynamics for 100 ps.
         solvent_boxdims=[70,70,70], nonbonded_pars="CM5_UFF", numcores=numcores)
 
     #Creating new OpenMM object from forcefield, topology and and fragment
-    openmmobject =OpenMMTheory(platform='OpenCL', numcores=numcores, Modeller=True, forcefield=forcefield, topology=topology, periodic=True,
+    soluteatoms=[i for i in range(0,mol.numatoms)]
+    openmmobject =OpenMMTheory(platform='OpenCL', numcores=numcores, forcefield=forcefield, topoforce=True, topology=topology, periodic=True, frozen_atoms=soluteatoms, 
         autoconstraints='HBonds', rigidwater=True)
 
 
     #MM minimization for 100 steps
-    soluteatoms=[i for i in range(0,mol.numatoms)]
-    OpenMM_Opt(fragment=ashfragment, theory=openmmobject, maxiter=100, tolerance=1, frozen_atoms=soluteatoms, enforcePeriodicBox=True)
+    OpenMM_Opt(fragment=ashfragment, theory=openmmobject, maxiter=100, tolerance=1, enforcePeriodicBox=True)
 
     #Classical MD simulation for 100 ps
     OpenMM_MD(fragment=ashfragment, theory=openmmobject, timestep=0.001, simulation_time=100, traj_frequency=10, temperature=300,
-        integrator='LangevinMiddleIntegrator', coupling_frequency=1, trajectory_file_option='DCD', frozen_atoms=soluteatoms, enforcePeriodicBox=True)
+        integrator='LangevinMiddleIntegrator', coupling_frequency=1, trajectory_file_option='DCD', enforcePeriodicBox=True)
 
     #MDAnalysis transforming of trajectory
     lastframe_elems, lastframe_coords = MDAnalysis_transform("final_MDfrag_laststep.pdb","output_traj.dcd", solute_indices=soluteatoms, 


### PR DESCRIPTION
Minor modification, in the tutorial on solvation of small molecules.
1.   Modeller=True is replaced with topoforce=True
2.   frozen_atoms=soluteatoms is included in OpenMMTheory (the setting of frozen_atoms is in OpenMMTheory, because I don't see an option about frozen_atoms in OpenMM_Opt and OpenMM_MD)
3.  Now "soluteatoms=[i for i in range(0,mol.numatoms)]" are placed in Configure the front of OpenMMTheory.
4.   output_traj. dcd is replaced by trajectory.dcd
I tested this in the ASH and Ash-new branches, and the changes should work.